### PR TITLE
adding rtm connection verify peer attribute to adapter config 

### DIFF
--- a/lib/lita/adapters/slack.rb
+++ b/lib/lita/adapters/slack.rb
@@ -14,6 +14,7 @@ module Lita
       config :unfurl_links, type: [true, false]
       config :unfurl_media, type: [true, false]
       config :supported_message_subtypes, type: Array, default: []
+      config :rtm_connection_verify_peer, type: [true, false], default: true
 
       # Provides an object for Slack-specific features.
       def chat_service

--- a/lib/lita/adapters/slack/rtm_connection.rb
+++ b/lib/lita/adapters/slack/rtm_connection.rb
@@ -47,6 +47,9 @@ module Lita
 
             websocket.on(:open) { log.debug("Connected to the Slack Real Time Messaging API.") }
             websocket.on(:message) { |event| receive_message(event) }
+            websocket.on(:error) do |event|
+              log.info("Slack Websocket error: #{event.message}")
+            end
             websocket.on(:close) do
               log.info("Disconnected from Slack.")
               EventLoop.safe_stop

--- a/lib/lita/adapters/slack/rtm_connection.rb
+++ b/lib/lita/adapters/slack/rtm_connection.rb
@@ -116,6 +116,7 @@ module Lita
         def websocket_options
           options = { ping: 10 }
           options[:proxy] = { :origin => config.proxy } if config.proxy
+          options[:verify_peer] = config.rtm_connection_verify_peer
           options
         end
 


### PR DESCRIPTION
this deals with the recent slack update where the slack team renewed slack.com's TLS certificate with a new Certificate Authority. 