### PR TITLE
update on websocket close with more descriptive logging

### DIFF
--- a/lib/lita/adapters/slack/rtm_connection.rb
+++ b/lib/lita/adapters/slack/rtm_connection.rb
@@ -50,8 +50,8 @@ module Lita
             websocket.on(:error) do |event|
               log.info("Slack Websocket error: #{event.message}")
             end
-            websocket.on(:close) do
-              log.info("Disconnected from Slack.")
+            websocket.on(:close) do |event|
+              log.info("Disconnected from Slack with event code and reason: #{event.code} - #{event.reason}")
               EventLoop.safe_stop
             end
             websocket.on(:error) { |event| log.debug("WebSocket error: #{event.message}") }


### PR DESCRIPTION
RTM connect API randomly closes websocket connection when on prod. Here we will add a bit more logging on Disconnect to see close event code and reason